### PR TITLE
Add support for psc-package

### DIFF
--- a/psc-ide.el
+++ b/psc-ide.el
@@ -88,7 +88,7 @@
   :group 'psc-ide
   :type  'integer)
 
-(defcustom psc-ide-source-globs '("src/**/*.purs" "bower_components/purescript-*/src/**/*.purs")
+(defcustom psc-ide-source-globs '("src/**/*.purs" "bower_components/purescript-*/src/**/*.purs" ".psc-package/**/*.purs")
   "The source globs for your PureScript source files."
   :group 'psc-ide
   :type  'sexp)


### PR DESCRIPTION
When the project is using `psc-package` as dependency manager, psc-ide doesn't load any libararies. So I added the path just in case.
Note that I can vouch whether that will slow down the server(because of the glob pattern)